### PR TITLE
Fix certificate url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
 ---
 data_source: "."
 update_frequency: One-off
-certificate_url: http://certificates.theodi.org/en/datasets/214192/certificate/badge.js
+certificate_url: https://certificates.theodi.org/en/datasets/214192/certificate/badge.js


### PR DESCRIPTION
This is a bug in Octopub I've just noticed. This will mean your Open Data Certificate will show as nature intended
