### PR TITLE
Palmerston is now inactive

### DIFF
--- a/data/main-list.csv
+++ b/data/main-list.csv
@@ -1,7 +1,7 @@
 uid,name,status,location,startdate,enddate,source,twitterhandle
 0,Larry,Active,10 Downing Street,2011-02-11,,https://en.wikipedia.org/wiki/Larry_(cat),@Number10cat
 1,Freya,Inactive,11 Downing Street,2012-09-16,2014-11-09,https://en.wikipedia.org/wiki/Freya_(cat),
-2,Palmerston,Active,Foreign and Commonwealth Office,2016-04-13,,https://en.wikipedia.org/wiki/Palmerston_(cat),@diplomog
+2,Palmerston,Inactive,Foreign and Commonwealth Office,2016-04-13,2020-08-07,https://en.wikipedia.org/wiki/Palmerston_(cat),@diplomog
 3,Gladstone,Active,HM Treasury,2016-06-01,,https://en.wikipedia.org/wiki/Gladstone_(cat),@HMTreasuryCat
 4,Cromwell,Inactive,Cabinet Office,,,http://www.telegraph.co.uk/news/2016/08/03/cabinet-office-set-to-appoint-cat-called-cromwell-as-chief-mouse/,
 5,Humphrey,Deceased,10 Downing Street,1988,2006-03,https://en.wikipedia.org/wiki/Humphrey_(cat),


### PR DESCRIPTION
A reasonably authoritative source is the [resignation letter on Palmerston's twitter account](https://twitter.com/DiploMog/status/1291618656678490117).

This account is [unverified](https://help.twitter.com/en/managing-your-account/twitter-verified-accounts), and not marked by twitter as an account of a [key government official](https://blog.twitter.com/en_us/topics/product/2020/new-labels-for-government-and-state-affiliated-media-accounts.html).

But the account is tagged in [tweets](https://twitter.com/SMcDonaldFCO/status/1291615282973245443) by the verified account of the current Permanent Under-Secretary at the FCO, [Simon McDonald](https://en.wikipedia.org/wiki/Simon_McDonald_(diplomat)) so seems reasonably authoritative.